### PR TITLE
Use JSON.stringify to output JSON

### DIFF
--- a/lib/env/lister.js
+++ b/lib/env/lister.js
@@ -8,13 +8,13 @@ const env       = require('./env.js')
 var lister = module.exports = {
     /**
      * Lists the environment variables in different formats.
-     * @param Array vars    The environment variables
+     * @param Object vars    The environment variables
      * @param String format Output format (f.i. 'json')
      * @return String       Output
      */
     list: function(vars, format) {
         if (format == 'json') {
-            return vars
+            return JSON.stringify(vars)
         }
 
         return lister._tablify(vars)

--- a/test/env.list.test.js
+++ b/test/env.list.test.js
@@ -28,7 +28,7 @@ describe('List', function() {
     describe('#env list --output=json', function() {
         it('should return a json list', function() {
             var result = lister.list(mockvars, 'json')
-            assert(typeof result === 'object', 'Is an object')
+            assert.equal(result, '{"FOO":"Foo","BAR":"Bar"}', "Is valid JSON");
         })
     })
     //describe('#initialize', function() {


### PR DESCRIPTION
`console.log(vars)` doesn't output valid JSON. It doesn't quote keys for example, and will use single quotes for string values.

`JSON.stringify` transforms any value into a formal JSON string.